### PR TITLE
Broadcast rework

### DIFF
--- a/packages/broadcast/component.js
+++ b/packages/broadcast/component.js
@@ -47,18 +47,9 @@ export class FabricBroadcast extends LitElement {
     }
   }
 
-  get _broadcasts() {
-    if (!windowExists) return this._messages;
-    const ignoredBroadcasts = JSON.parse(window.localStorage.getItem('ignored-broadcasts')) || [];
-    return this._messages.filter(({ id }) => !ignoredBroadcasts.includes(id));
-  }
-
   async _del(id) {
     const el = this.renderRoot.querySelector(`#${id}`);
     await el.collapse();
-    const ignoredBroadcasts = JSON.parse(window.localStorage.getItem('ignored-broadcasts')) || [];
-    ignoredBroadcasts.push(id.split('-')[1]);
-    window.localStorage.setItem('ignored-broadcasts', JSON.stringify(ignoredBroadcasts));
   }
 
   render() {
@@ -70,7 +61,7 @@ export class FabricBroadcast extends LitElement {
       />
       <aside>
         ${repeat(
-          this._broadcasts,
+          this._messages,
           ({ id }) => `broadcast-${id}`,
           ({ id, message }) => html`<f-toast
             class="w-full"

--- a/packages/broadcast/component.js
+++ b/packages/broadcast/component.js
@@ -1,6 +1,6 @@
-import { LitElement } from 'lit-element';
+import { LitElement, html } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
 import { windowExists } from '../utils';
-import { FabricToastContainer } from '../..';
 
 export class FabricBroadcast extends LitElement {
   static properties = {
@@ -23,7 +23,6 @@ export class FabricBroadcast extends LitElement {
     this._messages = [];
     this.interval = 30000;
     this.url = windowExists ? window.location.href : '';
-    this._toastContainer = FabricToastContainer.init();
   }
 
   async connectedCallback() {
@@ -33,24 +32,57 @@ export class FabricBroadcast extends LitElement {
       return;
     }
     if (windowExists) {
-      await this.fetchMessage();
-      setInterval(() => this.fetchMessage(), this.interval);
+      await this._fetchMessage();
+      setInterval(() => this._fetchMessage(), this.interval);
     }
   }
 
-  async fetchMessage() {
+  async _fetchMessage() {
     const url = `${this.api}?path=${this.url}`;
     try {
       const res = await (await fetch(url)).json();
       this._messages = res.length ? res : [];
     } catch (err) {
-      console.error(`failed to fetch broadcasts from given url (${url})`)
+      console.error(`failed to fetch broadcasts from given url (${url})`);
     }
   }
 
+  get _broadcasts() {
+    if (!windowExists) return this._messages;
+    const ignoredBroadcasts = JSON.parse(window.localStorage.getItem('ignored-broadcasts')) || [];
+    return this._messages.filter(({ id }) => !ignoredBroadcasts.includes(id));
+  }
+
+  async _del(id) {
+    const el = this.renderRoot.querySelector(`#${id}`);
+    await el.collapse();
+    const ignoredBroadcasts = JSON.parse(window.localStorage.getItem('ignored-broadcasts')) || [];
+    ignoredBroadcasts.push(id.split('-')[1]);
+    window.localStorage.setItem('ignored-broadcasts', JSON.stringify(ignoredBroadcasts));
+  }
+
   render() {
-    for (const { id, message: text } of this._messages) {
-      this._toastContainer.set({ id: `broadcast-${id}`, text, type: 'warning', canclose: true });
-    }
+    return html`
+      <link
+        rel="stylesheet"
+        type="text/css"
+        href="https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css"
+      />
+      <aside>
+        ${repeat(
+          this._broadcasts,
+          ({ id }) => `broadcast-${id}`,
+          ({ id, message }) => html`<f-toast
+            class="w-full"
+            id="broadcast-${id}"
+            type="warning"
+            text="${message}"
+            canclose
+            @close=${() => this._del(`broadcast-${id}`)}
+          >
+          </f-toast>`,
+        )}
+      </aside>
+    `;
   }
 }

--- a/packages/toast/svgs.js
+++ b/packages/toast/svgs.js
@@ -1,70 +1,64 @@
 import { html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 
-export const successSVG = (options) => html`
-    <svg
-        role="img"
-        aria-label="${options.typeLabel}"
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        fill="none"
-        viewBox="0 0 16 16"
-    >
-        <path
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="1.5"
-            d="M5.5 9l2 1.5L11 6"
-        />
-    </svg>`;
+export const successSVG = (options) => html`<svg
+  role="img"
+  aria-label="${options.typeLabel}"
+  xmlns="http://www.w3.org/2000/svg"
+  width="16"
+  height="16"
+  fill="none"
+  viewBox="0 0 16 16"
+>
+  <path
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="1.5"
+    d="M5.5 9l2 1.5L11 6"
+  />
+</svg>`;
 
 export const failureSVG = (options) => html`
-    <svg
-        role="img"
-        aria-label="${options.typeLabel}"
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        fill="none"
-        viewBox="0 0 16 16"
-        class="${classMap({
-            'transition-transform duration-200': true,
-            'transform-rotate-180': options.isInfo,
-        })}"
-    >
-        <path
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-miterlimit="10"
-            stroke-width="1.5"
-            d="M8 9V4"
-        />
-        <circle
-            cx="8"
-            cy="11.8"
-            r=".8"
-            fill="currentColor"
-        />
-    </svg>
+  <svg
+    role="img"
+    aria-label="${options.typeLabel}"
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    fill="none"
+    viewBox="0 0 16 16"
+    class="${classMap({
+      'transition-transform duration-200': true,
+      'transform-rotate-180': options.isInfo,
+    })}"
+  >
+    <path
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-miterlimit="10"
+      stroke-width="1.5"
+      d="M8 9V4"
+    />
+    <circle cx="8" cy="11.8" r=".8" fill="currentColor" />
+  </svg>
 `;
 
 export const closeSVG = () => html`
-    <svg
-        role="img"
-        aria-label="Lukk"
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        fill="none"
-        viewBox="0 0 16 16"
-    >
+  <svg
+    role="img"
+    aria-label="Lukk"
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    fill="none"
+    viewBox="0 0 16 16"
+  >
     <path
-        fill="currentColor"
-        fill-rule="evenodd"
-        d="M4.03 2.97a.75.75 0 00-1.06 1.06L6.94 8l-3.97 3.97a.75.75 0 101.06 1.06L8 9.06l3.97 3.97a.75.75 0 101.06-1.06L9.06 8l3.97-3.97a.75.75 0 00-1.06-1.06L8 6.94 4.03 2.97z"
-        clipRule="evenodd"
+      fill="currentColor"
+      fill-rule="evenodd"
+      d="M4.03 2.97a.75.75 0 00-1.06 1.06L6.94 8l-3.97 3.97a.75.75 0 101.06 1.06L8 9.06l3.97 3.97a.75.75 0 101.06-1.06L9.06 8l3.97-3.97a.75.75 0 00-1.06-1.06L8 6.94 4.03 2.97z"
+      clipRule="evenodd"
     />
-    </svg>
-`
+  </svg>
+`;

--- a/packages/toast/toast.js
+++ b/packages/toast/toast.js
@@ -7,13 +7,13 @@ import { closeSVG, successSVG, failureSVG } from './svgs';
 
 const classes = (definition) => {
   const defn = {};
-  for(const [key, value] of Object.entries(definition)) {
+  for (const [key, value] of Object.entries(definition)) {
     for (const className of key.split(' ')) {
       defn[className] = value;
     }
   }
   return classMap(defn);
-}
+};
 
 export class FabricToast extends LitElement {
   static styles = css`
@@ -103,7 +103,7 @@ export class FabricToast extends LitElement {
   get _iconMarkup() {
     return this._success
       ? successSVG({ typeLabel: this._typeLabel })
-      : failureSVG({ typeLabel: this.typeLabel, isInfo: this._info });
+      : failureSVG({ typeLabel: this._typeLabel, isInfo: this._info });
   }
 
   async collapse() {
@@ -138,9 +138,7 @@ export class FabricToast extends LitElement {
           ${when(
             this.canclose !== false,
             () =>
-              html`<button class="${c.toastClose}" @click="${this.close}">
-                ${closeSVG()}
-              </button>`,
+              html`<button class="${c.toastClose}" @click="${this.close}">${closeSVG()}</button>`,
             () => html``,
           )}
         </div>

--- a/pages/components/broadcast.html
+++ b/pages/components/broadcast.html
@@ -19,7 +19,8 @@
         <p><strong>interval</strong> — Refetch interval - <i>default: 300 000 (5 minutes)</i></p>
         <p>
           <strong>api</strong> - API endpoint to fetch broadcasts from. Use
-          <code>https://dev.finn.no/broadcasts</code> on dev and <code>https://finn.no/broadcasts</code> on prod. -
+          <code>https://dev.finn.no/broadcasts</code> on dev and
+          <code>https://finn.no/broadcasts</code> on prod. -
           <i>Required</i>
         </p>
         <p>
@@ -30,12 +31,25 @@
         <h2 class="mt-24 mb-16">Example usage</h2>
 
         <syntax-highlight>
+          <f-broadcast
+            api="https://dev.finn.no/broadcasts"
+            url="https:/dev.finn.no/meldinger"
+            interval="30000"
+          ></f-broadcast>
+        </syntax-highlight>
+
         <f-broadcast
           api="https://dev.finn.no/broadcasts"
           url="https:/dev.finn.no/meldinger"
           interval="30000"
         ></f-broadcast>
-        </syntax-highlight>
+
+        <button
+          class="button button--small mt-10"
+          onclick="window.localStorage.removeItem('ignored-broadcasts'); location.href = location.href;"
+        >
+          Restore Deleted Broadcasts
+        </button>
       </main>
       <%- include('footer.html'); -%>
     </f-docs-template>

--- a/pages/components/broadcast.html
+++ b/pages/components/broadcast.html
@@ -43,13 +43,6 @@
           url="https:/dev.finn.no/meldinger"
           interval="30000"
         ></f-broadcast>
-
-        <button
-          class="button button--small mt-10"
-          onclick="window.localStorage.removeItem('ignored-broadcasts'); location.href = location.href;"
-        >
-          Restore Deleted Broadcasts
-        </button>
       </main>
       <%- include('footer.html'); -%>
     </f-docs-template>

--- a/tests/broadcast/broadcast.test.js
+++ b/tests/broadcast/broadcast.test.js
@@ -9,7 +9,7 @@ test('Basic broadcast with defaults', async () => {
   await fixture(html`<f-broadcast api="http://localhost:4053/single-broadcast"></f-broadcast>`);
   await wait(500);
   const broadcasts = document
-    .querySelector('f-toast-container')
+    .querySelector('f-broadcast')
     .renderRoot.querySelectorAll('f-toast');
   expect(broadcasts.length).to.equal(1);
 });
@@ -37,7 +37,7 @@ test('Multiple broadcasts', async () => {
   await fixture(html`<f-broadcast api="http://localhost:4053/multiple-broadcasts"></f-broadcast>`);
   await wait(50);
   const broadcasts = document
-    .querySelector('f-toast-container')
+    .querySelector('f-broadcast')
     .renderRoot.querySelectorAll('f-toast');
   expect(broadcasts.length).to.equal(2);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -590,7 +590,7 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@isaacs/import-jsx@*", "@isaacs/import-jsx@^4.0.1":
+"@isaacs/import-jsx@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@isaacs/import-jsx/-/import-jsx-4.0.1.tgz#493cab5fc543a0703dba7c3f5947d6499028a169"
   integrity sha512-l34FEsEqpdYdGcQjRCxWy+7rHY6euUbOBz9FI+Mq6oQeVhNegHcXFSJxVxrJvOpO31NbnDjS74quKXDlPDearA==
@@ -1788,7 +1788,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react@*":
+"@types/react@^17":
   version "17.0.39"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
   integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
@@ -5286,7 +5286,7 @@ init-package-json@^1.10.3:
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
 
-ink@*, ink@^3.2.0:
+ink@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ink/-/ink-3.2.0.tgz#434793630dc57d611c8fe8fffa1db6b56f1a16bb"
   integrity sha512-firNp1q3xxTzoItj/eOOSZQnYSlyrWks5llCTVX37nJ59K3eXbQ8PtzCguqo8YI19EELo5QxaKnJd4VxzhU8tg==
@@ -7854,7 +7854,7 @@ react-reconciler@^0.26.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react@*:
+react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
@@ -9211,7 +9211,7 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-treport@*:
+treport@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/treport/-/treport-3.0.2.tgz#6503b6430b201620a20fef2892bc875dc6495116"
   integrity sha512-aMKalaiZMsTfTXIEnJEz7BT5aHzN+ZV5hFCrXZsCbRZxfGRop+7JQdXntBs1FHZc9W2zMHLxGHb42yf08l6/bw==


### PR DESCRIPTION
## PR Overview

This PR separates the Broadcast from the Toast implementation somewhat so that it can be placed inline at the appropriate location in a page/layout. It continues to use the `f-toast` component under the hood though this could be broken out at a later stage if the visual look of the toast ever diverged from that of broadcast.

## Discussion context

I have been going through broadcast and toast implementations with @martin-storsletten and followed up with discussion at Fabric standup this morning. It became clear that leveraging the toasts programmatic API for broadcasts was the wrong approach since the UX/Design side expects the broadcast to be inline and this sentiment is echoed on the UU side (expectation is that Broadcast should be placed at the top of the page under header before main content). This PR should address the issue.

## To run tests
```
npm run build
npm run test:mock-backend
```
Then in another tab
```
npm test
```

## To test visually
```
npm run build
npm run dev
```
Visit `http://localhost:3000/pages/components/broadcast.html`