### PR TITLE
refactor: configure accessible defaults and add guideline docs

### DIFF
--- a/packages/toast/api.js
+++ b/packages/toast/api.js
@@ -7,8 +7,8 @@ import { windowExists } from '../utils';
  * @property   {(number|string)}                      [id]        Custom identifier
  * @property   {('success'|'error'|'warning'|'info')} [type]      Type of alert
  * @property   {String}                               [text]      The toast message. Only needed when updating text on existing toast
- * @property   {(number|string)}                      [duration]  Duration of toast in milliseconds Set to 0 to disable auto-removal
- * @property   {Boolean}                              [canclose]  Can toast be dismissed?
+ * @property   {(number|string)}                      [duration]  Duration of toast in milliseconds. Defaults to 5000. For accessibility reasons, toasts should never be interactive and therefore need to auto remove. If you must disable auto remove, set duration to Number.POSITIVE_INFINITY.
+ * @property   {Boolean}                              [canclose]  Whether the toast can be dismissed. Defaults to false. WARNING! For accessibility reasons, toasts should not be interactive and canclose should always be false. If the toast absolutely must be dismissble, set this to true.
  */
 
 /**
@@ -24,7 +24,7 @@ export function toast(message, options) {
   const data = {
     id: Date.now().toString(36) + Math.random().toString(36).slice(2, 5),
     text: message,
-    duration: Number.POSITIVE_INFINITY,
+    duration: 5000,
     type: 'success',
     ...options,
   };

--- a/packages/toast/toast.js
+++ b/packages/toast/toast.js
@@ -136,7 +136,7 @@ export class FabricToast extends LitElement {
             <p>${this.text}</p>
           </div>
           ${when(
-            this.canclose !== false,
+            this.canclose === true,
             () =>
               html`<button class="${c.toastClose}" @click="${this.close}">${closeSVG()}</button>`,
             () => html``,

--- a/pages/components/toast.html
+++ b/pages/components/toast.html
@@ -7,6 +7,20 @@
         <h1 class="mb-16">Toast</h1>
 
         <p>
+          Toasts display small snippets of information to the user and then disappear after a set time.
+          The Fabric toast appears at the bottom of the screen but will normally be triggered by a user interaction somewhere else on the page.
+        </p>
+
+        <h2>Accessibility</h2>
+        <p>
+          For accessibility reasons, toasts should never contain interactive elements as interactive elements should always occur in the same location as the action that triggered it.
+          Because of this limitation, we consider the use of toasts to be somewhat of an antipattern and recommend that another approach be found wherever possible.
+          The Fabric team will be investigating potentially better approaches for specific use cases in near future.
+          That being said, you are free to use toast so long as you avoid using interactive elements such as links or a close button.
+        </p>
+
+        <h2>Usage</h2>
+        <p>
           The toast is intended to be used programmatically. JavaScript APIs are
           provided to create, update and remove toasts from a page while
           managing things like placement on the page for you.
@@ -87,18 +101,9 @@
         <p>Text content: <strong>text</strong> — default undefined</p>
 
         <syntax-highlight>
-          const id = toast('message goes here'); updateToast({ id, text: 'change
-          the message' });
+          const id = toast('message goes here');
+          updateToast({ id, text: 'change the message' });
         </syntax-highlight>
-
-        <div class="example">
-          <button
-            class="button button--small"
-            onclick="(() => { const id = window.toast('message goes here'); (setTimeout(() => window.updateToast({ id, text: 'change the message' })), 2000)() })()"
-          >
-            See Example
-          </button>
-        </div>
 
         <p>Auto removal: <strong>duration</strong> — default 5000ms</p>
 
@@ -115,20 +120,6 @@
           </button>
         </div>
 
-        <p>Closable: <strong>canclose</strong> — default true</p>
-
-        <syntax-highlight>
-          toast('message goes here', { canclose: false, duration: 2500 })
-        </syntax-highlight>
-
-        <div class="example">
-          <button
-            class="button button--small"
-            onclick="window.toast('message goes here', { canclose: false, duration: 2500 })"
-          >
-            See Example
-          </button>
-        </div>
       </main>
       <%- include('footer.html'); -%>
     </f-docs-template>


### PR DESCRIPTION
This PR makes adjustments to toast to tune and document accessibility.

Text is added to encourage people to find other solutions to toast OR at a minimum, not use interactive elements inside of a toast.

Defaults are configured such that by default no interactive elements will be present in a toast.