### PR TITLE
fix: decouple elements and toast api to fix SSR usage

### DIFF
--- a/packages/toast/api.js
+++ b/packages/toast/api.js
@@ -1,4 +1,3 @@
-import { FabricToastContainer } from './toast-container';
 import { windowExists } from '../utils';
 
 /**
@@ -19,7 +18,7 @@ import { windowExists } from '../utils';
  */
 export function toast(message, options) {
   if (!windowExists) return;
-  const toast = FabricToastContainer.init();
+  const toast = customElements.get('f-toast-container').init();
 
   const data = {
     id: Date.now().toString(36) + Math.random().toString(36).slice(2, 5),
@@ -40,7 +39,7 @@ export function toast(message, options) {
  */
 export function removeToast(id) {
   if (!windowExists) return;
-  const toast = FabricToastContainer.init();
+  const toast = customElements.get('f-toast-container').init();
   return toast.del(id);
 }
 
@@ -52,7 +51,7 @@ export function removeToast(id) {
  */
 export function updateToast(id, options) {
   if (!windowExists) return;
-  const toast = FabricToastContainer.init();
+  const toast = customElements.get('f-toast-container').init();
   toast.set({ ...toast.get(id), ...options });
   return toast.get(id);
 }

--- a/pages/components/toast.html
+++ b/pages/components/toast.html
@@ -33,12 +33,19 @@
 
         <p>Import functions for working with toasts:</p>
 
+        Be sure to import the elements package first as the toast APIs depend on this package.
+
         <syntax-highlight>
-          import { toast, removeToast, updateToast } from
-          '@fabric-ds/elements/toast';
+          import from '@fabric-ds/elements'
         </syntax-highlight>
 
-        Create a new toast giving it a message:
+        Once you have imported the elements package, import the toast api package.
+
+        <syntax-highlight>
+          import { toast, removeToast, updateToast } from '@fabric-ds/elements/toast';
+        </syntax-highlight>
+
+        Then you can create a new toast giving it a message:
         <syntax-highlight> toast('This is a toast'); </syntax-highlight>
 
         <div class="example">

--- a/tests/toast/toast-api.test.js
+++ b/tests/toast/toast-api.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 import { expect } from '@open-wc/testing';
-import { updateToast, removeToast, toast } from '../../dist/index.js';
+import '../../dist/index.js';
+import { updateToast, removeToast, toast } from '../../dist/api.js';
 
 const test = it;
 const wait = (duration = 0) =>


### PR DESCRIPTION
This removes the dependency on the main elements package from within the api package to enable it to be used SSR.
In practice it does nothing in SSR its just that when the 2 packages were coupled, errors were being thrown which this should avoid.