### PR TITLE
Add margin to broadcast & remove collapsed items from DOM

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,14 @@
 {
   "extends": ["eslint:recommended"],
   "env": {
-    "browser": true
+    "browser": true,
+    "es6": true
   },
   "parser": "babel-eslint",
   "parserOptions": {
     "sourceType": "module"
   },
   "rules": {
-    "no-unexpected-multiline": "off",
-    "no-undef": "off"
+    "no-unexpected-multiline": "off"
   }
 }

--- a/packages/broadcast/component.js
+++ b/packages/broadcast/component.js
@@ -13,7 +13,7 @@ export class FabricBroadcast extends LitElement {
         return JSON.stringify(newIds) !== JSON.stringify(oldIds);
       },
     },
-    hiddenMessageIds: {
+    _hiddenMessageIds: {
       state: true,
       type: Array,
     },
@@ -26,7 +26,7 @@ export class FabricBroadcast extends LitElement {
     super();
     this._messages = [];
     this.interval = 30000;
-    this.hiddenMessageIds = [];
+    this._hiddenMessageIds = [];
     this.url = windowExists ? window.location.href : '';
   }
 
@@ -55,14 +55,11 @@ export class FabricBroadcast extends LitElement {
   async _del(id) {
     const el = this.renderRoot.querySelector(`#broadcast-${id}`);
     await el.collapse();
-    this.hiddenMessageIds = [...this.hiddenMessageIds, id];
+    this._hiddenMessageIds = [...new Set([...this._hiddenMessageIds, id])];
   }
 
   render() {
-    const messages =
-      this.hiddenMessageIds.length > 0
-        ? this._messages.filter((item) => !this.hiddenMessageIds.includes(item.id))
-        : this._messages;
+    const messages = this._messages.filter((item) => !this._hiddenMessageIds.includes(item.id));
 
     return html`
       <link

--- a/packages/broadcast/component.js
+++ b/packages/broadcast/component.js
@@ -7,11 +7,15 @@ export class FabricBroadcast extends LitElement {
     _messages: {
       state: true,
       hasChanged(newVal, oldVal) {
-        if (!oldVal) return true;
+        if (!oldVal || oldVal.length === 0) return true;
         const newIds = newVal.map(({ id }) => id).sort();
         const oldIds = oldVal.map(({ id }) => id).sort();
         return JSON.stringify(newIds) !== JSON.stringify(oldIds);
       },
+    },
+    hiddenMessageIds: {
+      state: true,
+      type: Array,
     },
     interval: { type: Number, attribute: true, reflect: true },
     url: { type: String, attribute: true, reflect: true },
@@ -22,6 +26,7 @@ export class FabricBroadcast extends LitElement {
     super();
     this._messages = [];
     this.interval = 30000;
+    this.hiddenMessageIds = [];
     this.url = windowExists ? window.location.href : '';
   }
 
@@ -48,11 +53,17 @@ export class FabricBroadcast extends LitElement {
   }
 
   async _del(id) {
-    const el = this.renderRoot.querySelector(`#${id}`);
+    const el = this.renderRoot.querySelector(`#broadcast-${id}`);
     await el.collapse();
+    this.hiddenMessageIds = [...this.hiddenMessageIds, id];
   }
 
   render() {
+    const messages =
+      this.hiddenMessageIds.length > 0
+        ? this._messages.filter((item) => !this.hiddenMessageIds.includes(item.id))
+        : this._messages;
+
     return html`
       <link
         rel="stylesheet"
@@ -61,17 +72,18 @@ export class FabricBroadcast extends LitElement {
       />
       <aside>
         ${repeat(
-          this._messages,
+          messages,
           ({ id }) => `broadcast-${id}`,
-          ({ id, message }) => html`<f-toast
-            class="w-full"
-            id="broadcast-${id}"
-            type="warning"
-            text="${message}"
-            canclose
-            @close=${() => this._del(`broadcast-${id}`)}
-          >
-          </f-toast>`,
+          ({ id, message }) =>
+            html`<f-toast
+              class="w-full"
+              id="broadcast-${id}"
+              type="warning"
+              text="${message}"
+              canclose
+              @close=${() => this._del(id)}
+            >
+            </f-toast>`,
         )}
       </aside>
     `;

--- a/packages/broadcast/component.js
+++ b/packages/broadcast/component.js
@@ -70,7 +70,7 @@ export class FabricBroadcast extends LitElement {
         type="text/css"
         href="https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css"
       />
-      <aside>
+      <aside class=${`${messages.length === 0 ? 'hidden' : 'mb-16'}`}>
         ${repeat(
           messages,
           ({ id }) => `broadcast-${id}`,


### PR DESCRIPTION
## Issue
[FRON-530](https://finn-jira.atlassian.net/browse/FRON-530)

## Description
- adds bottom margin to broadcast wrapper
- removes collapsed broadcast items from DOM - otherwise bottom margin would still be applied after collapsing the last item

![broadcast](https://user-images.githubusercontent.com/41303231/165287575-606cc422-d780-4ace-b31d-e30bfee425bd.gif)


## Additionally
- restores Eslint rule for warning of non-defined variables

## Testing
- [ ] add tests