### PR TITLE
Box component

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 export * from './packages/card';
+export * from './packages/box';
 export * from './packages/breadcrumbs';
 export * from './packages/toast/toast';
 export * from './packages/toast/toast-container';

--- a/packages/box/index.js
+++ b/packages/box/index.js
@@ -1,0 +1,50 @@
+import { css, html } from 'lit';
+import { fclasses, FabricElement } from '../utils';
+import { box as boxClasses } from '@fabric-ds/css/component-classes';
+
+class FabricBox extends FabricElement {
+  static properties = {
+    bleed: { type: Boolean },
+    bordered: { type: Boolean },
+    info: { type: Boolean },
+    neutral: { type: Boolean },
+  };
+
+  // Slotted elements remain in lightDOM which allows for control of their style outside of shadowDOM.
+  // ::slotted([Simple Selector]) confirms to Specificity rules, but (being simple) does not add weight to lightDOM skin selectors,
+  // so never gets higher Specificity. Thus in order to overwrite style linked within shadowDOM, we need to use !important.
+  // https://stackoverflow.com/a/61631668
+  static styles = css`
+    :host {
+      display: block;
+    }
+    ::slotted(:last-child) {
+      margin-bottom: 0px !important;
+    }
+  `;
+
+  get _class() {
+    return fclasses({
+      [boxClasses.box]: true,
+      [boxClasses.bleed]: this.bleed,
+      'bg-aqua-50': this.info,
+      'bg-bluegray-100': this.neutral,
+      'border-2 border-bluegray-300': this.bordered,
+    });
+  }
+
+  render() {
+    return html`
+      ${this._fabricStylesheet}
+      <div class="${this._class}">
+        <slot></slot>
+      </div>
+    `;
+  }
+}
+
+if (!customElements.get('f-box')) {
+  customElements.define('f-box', FabricBox);
+}
+
+export { FabricBox };

--- a/packages/box/test.js
+++ b/packages/box/test.js
@@ -1,0 +1,168 @@
+/* eslint-disable no-undef */
+import tap, { test, beforeEach, teardown } from 'tap';
+import { chromium } from 'playwright';
+
+tap.before(async () => {
+  const browser = await chromium.launch({ headless: true });
+  tap.context.browser = browser;
+});
+
+beforeEach(async (t) => {
+  const { browser } = t.context;
+  const context = await browser.newContext();
+  t.context.page = await context.newPage();
+});
+
+teardown(async () => {
+  const { browser } = tap.context;
+  browser.close();
+});
+
+test('Box component with no attributes is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-box>
+      <p>This is a box</p>
+    </f-box>
+  `;
+
+  // WHEN: the component is added to the page
+  const { page } = t.context;
+  await page.setContent(component);
+  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+
+  // THEN: the component is visible in the DOM
+  const locator = await page.locator('f-box');
+  t.equal((await locator.innerHTML()).trim(), '<p>This is a box</p>', 'HTML should be rendered');
+  t.equal(await locator.getAttribute('bleed'), null, 'Bleed attribute should be null');
+  t.equal(await locator.getAttribute('bordered'), null, 'Bordered attribute should be null');
+  t.equal(await locator.getAttribute('info'), null, 'Info attribute should be null');
+  t.equal(await locator.getAttribute('neutral'), null, 'Neutral attribute should be null');
+});
+
+test('Box component with bordered attribute', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-box bordered>
+      <p>This is a box</p>
+    </f-box>
+  `;
+
+  // WHEN: the component is added to the page
+  const { page } = t.context;
+  await page.setContent(component);
+  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+
+  // THEN: the component is visible in the DOM
+  const locator = await page.locator('f-box');
+  t.equal(await locator.evaluate((el) => el.bordered), true, 'Bordered property should be true');
+  t.equal(await locator.getAttribute('bordered'), '', 'Bordered attribute should be set');
+  t.equal(await locator.getAttribute('info'), null, 'Info attribute should be null');
+  t.equal(await locator.getAttribute('neutral'), null, 'Neutral attribute should be null');
+  t.equal(await locator.getAttribute('bleed'), null, 'Bleed attribute should be null');
+});
+
+test('Box component with info attribute', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-box info>
+      <p>This is a box</p>
+    </f-box>
+  `;
+
+  // WHEN: the component is added to the page
+  const { page } = t.context;
+  await page.setContent(component);
+  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+
+  // THEN: the component is visible in the DOM
+  const locator = await page.locator('f-box');
+  t.equal(await locator.evaluate((el) => el.info), true, 'Info property should be true');
+  t.equal(await locator.getAttribute('info'), '', 'Info attribute should be set');
+});
+
+test('Box component with neutral attribute', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-box neutral>
+      <p>This is a box</p>
+    </f-box>
+  `;
+
+  // WHEN: the component is added to the page
+  const { page } = t.context;
+  await page.setContent(component);
+  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+
+  // THEN: the component is visible in the DOM
+  const locator = await page.locator('f-box');
+  t.equal(await locator.evaluate((el) => el.neutral), true, 'Neutral property should be true');
+  t.equal(await locator.getAttribute('neutral'), '', 'Neutral attribute should be set');
+});
+
+test('Box component with bleed attribute', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-box bleed>
+      <p>This is a box</p>
+    </f-box>
+  `;
+
+  // WHEN: the component is added to the page
+  const { page } = t.context;
+  await page.setContent(component);
+  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+
+  // THEN: the component is visible in the DOM
+  const locator = await page.locator('f-box');
+  t.equal(await locator.evaluate((el) => el.bleed), true, 'Bleed property should be true');
+  t.equal(await locator.getAttribute('bleed'), '', 'Bleed attribute should be set');
+});
+
+test('Box component with paragraph child elements', async (t) => {
+  // GIVEN: A component with 3 paragraphs
+  const component = `
+    <f-box>
+      <p>Paragraph 1</p>
+      <p id="second">Paragraph 2</p>
+      <p id="last">Paragraph 3</p>
+    </f-box>
+  `;
+
+  // WHEN: the component is added to the page
+  const { page } = t.context;
+  await page.setContent(component);
+  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+
+  // THEN: there should be three paragraphs in the DOM
+  t.equal(await page.locator('f-box p').count(), 3, '3 p tags should be present');
+  t.match(
+    await page.innerText(':nth-match(f-box p, 1)'),
+    'Paragraph 1',
+    'The first text should be "Paragraph 1"',
+  );
+  t.match(
+    await page.innerText(':nth-match(f-box p, 3)'),
+    'Paragraph 3',
+    'The third text should be "Paragraph 3"',
+  );
+
+  const secondElement = await page.locator('#second');
+  const lastElement = await page.locator('#last');
+
+  t.match(
+    await lastElement.evaluate((el) => {
+      return window.getComputedStyle(el).getPropertyValue('margin-bottom');
+    }),
+    '0px',
+    'Bottom margin of last paragraph should be 0px',
+  );
+
+  t.match(
+    await secondElement.evaluate((el) => {
+      return window.getComputedStyle(el).getPropertyValue('margin-bottom');
+    }),
+    '16px',
+    'Bottom margin of second paragraph should be 16px',
+  );
+});

--- a/packages/box/test.js
+++ b/packages/box/test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 import tap, { test, beforeEach, teardown } from 'tap';
 import { chromium } from 'playwright';
+import { addContentToPage } from '../../tests/utils/index.js';
 
 tap.before(async () => {
   const browser = await chromium.launch({ headless: true });
@@ -27,9 +28,10 @@ test('Box component with no attributes is rendered on the page', async (t) => {
   `;
 
   // WHEN: the component is added to the page
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
 
   // THEN: the component is visible in the DOM
   const locator = await page.locator('f-box');
@@ -49,9 +51,10 @@ test('Box component with bordered attribute', async (t) => {
   `;
 
   // WHEN: the component is added to the page
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
 
   // THEN: the component is visible in the DOM
   const locator = await page.locator('f-box');
@@ -71,9 +74,10 @@ test('Box component with info attribute', async (t) => {
   `;
 
   // WHEN: the component is added to the page
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
 
   // THEN: the component is visible in the DOM
   const locator = await page.locator('f-box');
@@ -90,9 +94,10 @@ test('Box component with neutral attribute', async (t) => {
   `;
 
   // WHEN: the component is added to the page
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
 
   // THEN: the component is visible in the DOM
   const locator = await page.locator('f-box');
@@ -109,9 +114,10 @@ test('Box component with bleed attribute', async (t) => {
   `;
 
   // WHEN: the component is added to the page
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
 
   // THEN: the component is visible in the DOM
   const locator = await page.locator('f-box');
@@ -130,9 +136,10 @@ test('Box component with paragraph child elements', async (t) => {
   `;
 
   // WHEN: the component is added to the page
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
 
   // THEN: there should be three paragraphs in the DOM
   t.equal(await page.locator('f-box p').count(), 3, '3 p tags should be present');

--- a/packages/card/test.js
+++ b/packages/card/test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 import tap, { test, beforeEach, teardown } from 'tap';
 import { chromium } from 'playwright';
+import { addContentToPage } from '../../tests/utils/index.js';
 
 tap.before(async () => {
   const browser = await chromium.launch({ headless: true });
@@ -27,9 +28,10 @@ test('Card component with no attributes is rendered on the page', async (t) => {
   `;
 
   // WHEN: the component is added to the page
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
 
   // THEN:
   const locator = await page.locator('f-card');
@@ -66,9 +68,10 @@ test('Card component with selected attribute', async (t) => {
   `;
 
   // WHEN: the component is added to the page
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
 
   // THEN:
   const locator = await page.locator('f-card');
@@ -96,9 +99,10 @@ test('Card component with flat attribute', async (t) => {
   `;
 
   // WHEN: the component is added to the page
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
 
   // THEN:
   const locator = await page.locator('f-card');
@@ -126,9 +130,10 @@ test('Card component with clickable attribute', async (t) => {
   `;
 
   // WHEN: the component is added to the page
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
 
   // THEN:
   const locator = await page.locator('f-card');
@@ -170,9 +175,10 @@ test('Card component with clickable attribute is usable by keyboard', async (t) 
   `;
 
   // WHEN: the component is added to the page and page interaction is performed
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
   await page.keyboard.press('Tab');
   await page.keyboard.press('Enter');
 
@@ -195,9 +201,10 @@ test('Card component with clickable attribute is usable by keyboard but alt+ente
   `;
 
   // WHEN: the component is added to the page and page interaction is performed
-  const { page } = t.context;
-  await page.setContent(component);
-  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
   await page.keyboard.press('Tab');
   await page.keyboard.press('Alt+Enter');
 

--- a/pages/components/box.html
+++ b/pages/components/box.html
@@ -64,23 +64,23 @@
 
         <syntax-highlight>
           <f-box info="true">
-            <h3>I am info box</h3>
+            <h3>I am an info box</h3>
           </f-box>
         </syntax-highlight>
         <div class="example">
           <f-box info>
-            <h3>I am info box</h3>
+            <h3>I am an info box</h3>
           </f-box>
         </div>
 
         <syntax-highlight>
           <f-box bordered="true">
-            <h3>I am bordered box</h3>
+            <h3>I am a bordered box</h3>
           </f-box>
         </syntax-highlight>
         <div class="example">
           <f-box bordered="true">
-            <h3>I am bordered box</h3>
+            <h3>I am a bordered box</h3>
           </f-box>
         </div>
 
@@ -134,8 +134,8 @@
         </div>
         <h2 class="mt-24 mb-16">Accessibility</h2>
         <p>
-          Use ARIA <code>role</code> attribute to provide semantic meaning to box element. Read more
-          about <code>role</code> types
+          Use the ARIA <code>role</code> attribute to provide semantic meaning to a box element.
+          Read more about <code>role</code> types
           <a
             target="_blank"
             title="Read more about ARIA role types on MDN"
@@ -147,12 +147,12 @@
 
         <syntax-highlight>
           <f-box bordered="true" role="section">
-            <h3>I am described as section to screen readers and other tools</h3>
+            <h3>I am treated as a section element by screen readers and other tools</h3>
           </f-box>
         </syntax-highlight>
         <div class="example">
           <f-box bordered role="section">
-            <h3>I am described as section to screen readers and other tools</h3>
+            <h3>I am treated as a section element by screen readers and other tools</h3>
           </f-box>
         </div>
       </main>

--- a/pages/components/box.html
+++ b/pages/components/box.html
@@ -1,0 +1,164 @@
+<html lang="en">
+  <%- include('head.html'); -%>
+  <body>
+    <f-docs-template>
+      <%- include('nav.html'); -%>
+      <main slot="content">
+        <h1 class="mb-16">Box</h1>
+        <p>Box is a layout component used for separating content areas on a page.</p>
+
+        <h2 class="mt-24 mb-16">Props</h2>
+        <table class="w-full docs-table">
+          <thead>
+            <tr class="text-left text-gray-400 uppercase">
+              <th>prop</th>
+              <th>type</th>
+              <th>default</th>
+            </tr>
+          </thead>
+          <tbody class="align-top">
+            <tr>
+              <td>bleed</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">Will make a box full-width on mobile</div>
+              </td>
+              <td>false</td>
+            </tr>
+            <tr>
+              <td>bordered</td>
+              <td>boolean</td>
+              <td>false</td>
+            </tr>
+            <tr>
+              <td>info</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">Will style the box with light blue colors</div>
+              </td>
+              <td>false</td>
+            </tr>
+            <tr>
+              <td>neutral</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">Will style the box with light gray colors</div>
+              </td>
+              <td>false</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2 class="mt-24 mb-16">Visual Options</h2>
+
+        <syntax-highlight>
+          <f-box>
+            <h3>I have default styles</h3>
+          </f-box>
+        </syntax-highlight>
+        <div class="example">
+          <f-box>
+            <h3>I have default styles</h3>
+          </f-box>
+        </div>
+
+        <syntax-highlight>
+          <f-box info="true">
+            <h3>I am info box</h3>
+          </f-box>
+        </syntax-highlight>
+        <div class="example">
+          <f-box info>
+            <h3>I am info box</h3>
+          </f-box>
+        </div>
+
+        <syntax-highlight>
+          <f-box bordered="true">
+            <h3>I am bordered box</h3>
+          </f-box>
+        </syntax-highlight>
+        <div class="example">
+          <f-box bordered="true">
+            <h3>I am bordered box</h3>
+          </f-box>
+        </div>
+
+        <syntax-highlight>
+          <f-box neutral="true">
+            <h3>I am a neutral colour</h3>
+          </f-box>
+        </syntax-highlight>
+        <div class="example">
+          <f-box neutral>
+            <h3>I am a neutral colour</h3>
+          </f-box>
+        </div>
+
+        <syntax-highlight>
+          <f-box neutral="true" bleed="true">
+            <h3>I am full width on mobile</h3>
+          </f-box>
+        </syntax-highlight>
+        <div class="example">
+          <f-box neutral bleed>
+            <h3>I am full width on mobile</h3>
+          </f-box>
+        </div>
+
+        <syntax-highlight>
+          <f-box info class="w-full lg:w-2/4 md:w-2/4">
+            <h3 class="mb-16">Info box</h3>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi malesuada dui in
+              commodo dapibus.
+            </p>
+            <div class="my-16">
+              <a title="This is a link">This is a link</a>
+            </div>
+            <button class="button button--small" onclick="alert('clicked!');">Button</button>
+          </f-box>
+        </syntax-highlight>
+        <div class="example">
+          <f-box info class="w-full lg:w-2/4 md:w-2/4">
+            <h3 class="mb-16">Info box</h3>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi malesuada dui in
+              commodo dapibus.
+            </p>
+            <div class="my-16">
+              <a title="This is a link">This is a link</a>
+            </div>
+            <button class="button button--small" onclick="alert('clicked!');">Button</button>
+          </f-box>
+        </div>
+        <h2 class="mt-24 mb-16">Accessibility</h2>
+        <p>
+          Use ARIA <code>role</code> attribute to provide semantic meaning to box element. Read more
+          about <code>role</code> types
+          <a
+            target="_blank"
+            title="Read more about ARIA role types on MDN"
+            class="text-current hover:no-underline focus:no-underline"
+            href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#aria_role_types"
+            ><u> on MDN</u></a
+          >.
+        </p>
+
+        <syntax-highlight>
+          <f-box bordered="true" role="section">
+            <h3>I am described as section to screen readers and other tools</h3>
+          </f-box>
+        </syntax-highlight>
+        <div class="example">
+          <f-box bordered role="section">
+            <h3>I am described as section to screen readers and other tools</h3>
+          </f-box>
+        </div>
+      </main>
+      <%- include('footer.html'); -%>
+    </f-docs-template>
+
+    <%- include('scripts.html'); -%>
+  </body>
+</html>

--- a/pages/includes/nav.html
+++ b/pages/includes/nav.html
@@ -11,6 +11,10 @@
             "href": "/pages/components/broadcast.html"
           },
           {
+            "title": "Box",
+            "href": "/pages/components/box.html"
+          },
+          {
             "title": "Card",
             "href": "/pages/components/card.html"
           },

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1,0 +1,7 @@
+export async function addContentToPage({ page, content }) {
+  let updatedPage = page;
+  await page.setContent(content);
+  await page.addScriptTag({ path: './dist/index.js', type: 'module' });
+
+  return updatedPage;
+}


### PR DESCRIPTION
Fixes [FRON-554](https://finn-jira.atlassian.net/browse/FRON-554)

Ads Box web component using Lit.

This component is different from React and Vue version with regards to the following:
- `as` property has been removed and the documentation instructs users to set a `role` attribute instead if necessary
- `clickable` property has been removed. According to [Figma UI Kit](https://www.figma.com/file/HVYESlqTcvocUF4cin482l/Fabric---UI-Kit?node-id=185%3A0) Box is never used as a clickable element. Users should use `Card` for this purpose instead. 

We might want to update React and Vue Box for the sake of consistency.

<img width="745" alt="Screenshot 2022-05-12 at 13 51 41" src="https://user-images.githubusercontent.com/41303231/168070384-8fc05255-1da5-4560-999c-dcd5001773da.png">
<img width="736" alt="Screenshot 2022-05-12 at 13 52 17" src="https://user-images.githubusercontent.com/41303231/168070396-625f6a54-be91-4e4d-80c5-80b840876e38.png">


TODO:
- [x] Implementation
- [x] Documentation
- [x] Tests