### PR TITLE
fix(expand-transition): don't set aria-hidden if value is false

### DIFF
--- a/packages/alert/test.js
+++ b/packages/alert/test.js
@@ -139,8 +139,8 @@ test('Negative alert component with show attribute is rendered on the page', asy
     await page.evaluate(
       'document.querySelector("f-alert").renderRoot.querySelector("f-expand-transition").renderRoot.querySelector("div").getAttribute("aria-hidden")',
     ),
-    'false',
-    'Aria-hidden attribute is `false`',
+    null,
+    'Aria-hidden attribute is missing',
   );
 
   page.removeListener('pageerror', registerErrorLogs);

--- a/packages/utils/expand-transition.js
+++ b/packages/utils/expand-transition.js
@@ -26,6 +26,10 @@ class ExpandTransition extends FabricElement {
     }
   }
 
+  firstUpdated() {
+    this._mounted = true;
+  }
+
   updated() {
     if (!this._wrapper) return;
 
@@ -36,10 +40,6 @@ class ExpandTransition extends FabricElement {
 
     if (this._mounted && !this.show && !this._removeElement) {
       collapse(this._wrapper, () => (this._removeElement = true));
-    }
-
-    if (!this._mounted) {
-      this._mounted = true;
     }
   }
 

--- a/packages/utils/expand-transition.js
+++ b/packages/utils/expand-transition.js
@@ -1,6 +1,7 @@
 import { css, html } from 'lit';
 import { collapse, expand } from 'element-collapse';
 import { FabricElement } from '.';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 class ExpandTransition extends FabricElement {
   static properties = {
@@ -54,7 +55,7 @@ class ExpandTransition extends FabricElement {
   `;
 
   render() {
-    return html`<div aria-hidden=${!this.show}>
+    return html`<div aria-hidden=${ifDefined(!this.show ? 'true' : undefined)}>
       ${this._removeElement ? html`` : html`<slot></slot>`}
     </div>`;
   }


### PR DESCRIPTION
The [W3C recommendation](https://www.w3.org/TR/wai-aria-1.2/#aria-hidden) suggests that we use `aria-hidden="false"` with caution due to potential issues on some browsers:
> At the time of this writing, [aria-hidden](https://www.w3.org/TR/wai-aria-1.2/#aria-hidden)="false" is known to work inconsistently in browsers. As future implementations improve, use caution and test thoroughly before relying on this approach.

It then makes sense to set the `aria-hidden` attribute only if its value is `true`.

Note: We cannot make `aria-hidden` a Boolean Attribute like so`<div ?aria-hidden=${!this.show}>` because if the expression evaluates to a truthy value, we'd get `aria-hidden=""` instead of `aria-hidden="true"`, and `aria-hidden` accepts only `true/false/undefined` values. 