### PR TITLE
feat: add textfield custom element

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,4 +6,5 @@ export * from './packages/toast/toast';
 export * from './packages/toast/toast-container';
 export * from './packages/toast/api';
 export * from './packages/broadcast';
+export * from './packages/textfield';
 export * from './packages/utils/expand-transition';

--- a/index.js
+++ b/index.js
@@ -7,4 +7,5 @@ export * from './packages/toast/toast-container';
 export * from './packages/toast/api';
 export * from './packages/broadcast';
 export * from './packages/textfield';
+export * from './packages/affix';
 export * from './packages/utils/expand-transition';

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "@fabric-ds/core": "0.0.15",
     "@open-wc/testing": "3.1.6",
     "glob": "^8.0.3",
-    "html-format": "1.0.2"
+    "html-format": "1.0.2",
+    "lit": "^2.3.1"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "license": "ISC",
   "devDependencies": {
+    "@babel/core": "^7.18.13",
     "@babel/eslint-parser": "7.18.9",
     "@chbphone55/classnames": "2.0.0",
     "@eik/cli": "2.0.22",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "dependencies": {
     "@fabric-ds/core": "0.0.15",
     "@open-wc/testing": "3.1.6",
+    "glob": "^8.0.3",
     "html-format": "1.0.2"
   },
   "publishConfig": {

--- a/packages/affix/icons.js
+++ b/packages/affix/icons.js
@@ -1,0 +1,47 @@
+import { html } from 'lit';
+
+export const clear = html`
+  <svg
+    role="img"
+    aria-label="X"
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    fill="none"
+    viewBox="0 0 16 16"
+  >
+    <path
+      fill="currentColor"
+      fillRule="evenodd"
+      d="M4.03 2.97a.75.75 0 00-1.06 1.06L6.94 8l-3.97 3.97a.75.75 0 101.06 1.06L8 9.06l3.97 3.97a.75.75 0 101.06-1.06L9.06 8l3.97-3.97a.75.75 0 00-1.06-1.06L8 6.94 4.03 2.97z"
+      clipRule="evenodd"
+    />
+  </svg>
+`;
+
+export const search = html`
+  <svg
+    role="img"
+    aria-label="Forstørrelsesglass"
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    fill="none"
+    viewBox="0 0 16 16"
+  >
+    <g
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      clipPath="url(#nra-cclip0)"
+    >
+      <path d="M8.796 11.803A5.684 5.684 0 104.349 1.341a5.684 5.684 0 004.447 10.462zM11 11l4 4" />
+    </g>
+    <defs>
+      <clipPath id="nra-cclip0">
+        <path fill="currentColor" d="M0 0h16v16H0z" />
+      </clipPath>
+    </defs>
+  </svg>
+`;

--- a/packages/affix/index.js
+++ b/packages/affix/index.js
@@ -7,15 +7,13 @@ import { fclasses, FabricElement } from '../utils';
 class FabricAffix extends FabricElement {
   static properties = {
     ariaLabel: { type: String, attribute: 'aria-label' },
-    prefix: { type: Boolean, reflect: true },
-    suffix: { type: Boolean, reflect: true },
     clear: { type: Boolean },
     search: { type: Boolean },
     label: { type: String },
   };
 
   get _classBase() {
-    return this.prefix ? prefix : suffix;
+    return this.slot === 'suffix' ? suffix : prefix;
   }
 
   get _classes() {

--- a/packages/affix/index.js
+++ b/packages/affix/index.js
@@ -1,0 +1,72 @@
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { suffix, prefix } from '@fabric-ds/css/component-classes';
+import { search, clear } from './icons';
+import { fclasses, FabricElement } from '../utils';
+
+class FabricAffix extends FabricElement {
+  static properties = {
+    ariaLabel: { type: String, attribute: 'aria-label' },
+    prefix: { type: Boolean, reflect: true },
+    suffix: { type: Boolean, reflect: true },
+    clear: { type: Boolean },
+    search: { type: Boolean },
+    label: { type: String },
+  };
+
+  get _classBase() {
+    return this.prefix ? prefix : suffix;
+  }
+
+  get _classes() {
+    return fclasses({
+      [this._classBase.wrapper]: true,
+      [this._classBase.wrapperWithLabel]: this.label,
+      [this._classBase.wrapperWithIcon]: !this.label,
+    });
+  }
+
+  get _searchButton() {
+    return html`
+      <button aria-label="${ifDefined(this.ariaLabel)}" class="${this._classes}" type="submit">
+        ${search}
+      </button>
+    `;
+  }
+
+  get _clearButton() {
+    return html`
+      <button aria-label="${ifDefined(this.ariaLabel)}" class="${this._classes}" type="reset">
+        ${clear}
+      </button>
+    `;
+  }
+
+  get _text() {
+    return html`
+      <div class="${this._classes}">
+        <span class="${this._classBase.label}">${this.label}</span>
+      </div>
+    `;
+  }
+
+  get _markup() {
+    if (this.label) {
+      return this._text;
+    } else if (this.search) {
+      return this._searchButton;
+    } else if (this.clear) {
+      return this._clearButton;
+    }
+  }
+
+  render() {
+    return html`${this._fabricStylesheet}${this._markup}`;
+  }
+}
+
+if (!customElements.get('f-affix')) {
+  customElements.define('f-affix', FabricAffix);
+}
+
+export { FabricAffix };

--- a/packages/textfield/index.js
+++ b/packages/textfield/index.js
@@ -92,23 +92,13 @@ class FabricTextField extends FabricElement {
   prefixSlotChange(e) {
     const el = this.renderRoot.querySelector('slot[name=prefix]');
     const affixes = el.assignedElements();
-    if (affixes.length) {
-      this._hasPrefix = true;
-      for (const affix of affixes) {
-        // tell the element that it is a prefix
-        affix.setAttribute('prefix', '');
-      }
-    }
+    if (affixes.length) this._hasPrefix = true;
   }
 
   suffixSlotChange(e) {
     const el = this.renderRoot.querySelector('slot[name=suffix]');
     const affixes = el.assignedElements();
     if (affixes.length) this._hasSuffix = true;
-    for (const affix of affixes) {
-      // tell the element that it is a suffix
-      affix.setAttribute('suffix', '');
-    }
   }
 
   render() {

--- a/packages/textfield/index.js
+++ b/packages/textfield/index.js
@@ -21,6 +21,8 @@ class FabricTextField extends FabricElement {
     required: { type: Boolean },
     type: { type: String },
     value: { type: String },
+    _hasPrefix: { state: true },
+    _hasSuffix: { state: true },
   };
 
   // Slotted elements remain in lightDOM which allows for control of their style outside of shadowDOM.
@@ -43,8 +45,8 @@ class FabricTextField extends FabricElement {
 
   get _outerWrapperStyles() {
     return fclasses({
-      // 'has-suffix': hasSuffix,
-      // 'has-prefix': hasPrefix,
+      'has-suffix': this._hasSuffix,
+      'has-prefix': this._hasPrefix,
     });
   }
 
@@ -82,9 +84,31 @@ class FabricTextField extends FabricElement {
         name,
         value,
         target: e.target,
-      }
-    })
+      },
+    });
     this.dispatchEvent(event);
+  }
+
+  prefixSlotChange(e) {
+    const el = this.renderRoot.querySelector('slot[name=prefix]');
+    const affixes = el.assignedElements();
+    if (affixes.length) {
+      this._hasPrefix = true;
+      for (const affix of affixes) {
+        // tell the element that it is a prefix
+        affix.setAttribute('prefix', '');
+      }
+    }
+  }
+
+  suffixSlotChange(e) {
+    const el = this.renderRoot.querySelector('slot[name=suffix]');
+    const affixes = el.assignedElements();
+    if (affixes.length) this._hasSuffix = true;
+    for (const affix of affixes) {
+      // tell the element that it is a suffix
+      affix.setAttribute('suffix', '');
+    }
   }
 
   render() {
@@ -94,6 +118,7 @@ class FabricTextField extends FabricElement {
         <div class="${this._innerWrapperStyles}">
           ${this._label}
           <div class="relative">
+            <slot @slotchange="${this.prefixSlotChange}" name="prefix"></slot>
             <input
               type="${this.type}"
               min="${ifDefined(this.min)}"
@@ -116,7 +141,7 @@ class FabricTextField extends FabricElement {
               @change="${this.handler}"
               @focus="${this.handler}"
             />
-            <slot></slot>
+            <slot @slotchange="${this.suffixSlotChange}" name="suffix"></slot>
           </div>
           ${this.helpText &&
           html`<div class="input__sub-text" id="${this._helpId}">${this.helpText}</div>`}

--- a/packages/textfield/index.js
+++ b/packages/textfield/index.js
@@ -9,6 +9,7 @@ class FabricTextField extends FabricElement {
     id: { type: String },
     label: { type: String },
     helpText: { type: String, attribute: 'help-text' },
+    size: { type: String },
     max: { type: Number },
     min: { type: Number },
     minLength: { type: Number, attribute: 'min-length' },
@@ -74,16 +75,16 @@ class FabricTextField extends FabricElement {
     if (this.invalid && this._helpId) return this._helpId;
   }
 
-  blurHandler(e) {
-    this.dispatchEvent(new CustomEvent('blur'));
-  }
-
-  changeHandler(e) {
-    this.dispatchEvent(new CustomEvent('change'));
-  }
-
-  focusHandler(e) {
-    this.dispatchEvent(new CustomEvent('focus'));
+  handler(e) {
+    const { name, value } = e.target;
+    const event = new CustomEvent(e.type, {
+      detail: {
+        name,
+        value,
+        target: e.target,
+      }
+    })
+    this.dispatchEvent(event);
   }
 
   render() {
@@ -97,6 +98,7 @@ class FabricTextField extends FabricElement {
               type="${this.type}"
               min="${ifDefined(this.min)}"
               max="${ifDefined(this.max)}"
+              size="${ifDefined(this.size)}"
               minlength="${ifDefined(this.minLength)}"
               maxlength="${ifDefined(this.maxLength)}"
               name="${ifDefined(this.name)}"
@@ -110,9 +112,9 @@ class FabricTextField extends FabricElement {
               ?disabled="${this.disabled}"
               ?readonly="${this.readOnly}"
               ?required="${this.required}"
-              @onBlur=${this.blurHandler}
-              @onChange=${this.changeHandler}
-              @onFocus=${this.focusHandler}
+              @blur="${this.handler}"
+              @change="${this.handler}"
+              @focus="${this.handler}"
             />
             <slot></slot>
           </div>

--- a/packages/textfield/index.js
+++ b/packages/textfield/index.js
@@ -1,0 +1,131 @@
+import { css, html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { fclasses, FabricElement } from '../utils';
+
+class FabricTextField extends FabricElement {
+  static properties = {
+    disabled: { type: Boolean },
+    invalid: { type: Boolean },
+    id: { type: String },
+    label: { type: String },
+    helpText: { type: String, attribute: 'help-text' },
+    max: { type: Number },
+    min: { type: Number },
+    minLength: { type: Number, attribute: 'min-length' },
+    maxLength: { type: Number, attribute: 'max-length' },
+    name: { type: String },
+    pattern: { type: String },
+    placeholder: { type: String },
+    readOnly: { type: Boolean, attribute: 'read-only' },
+    required: { type: Boolean },
+    type: { type: String },
+    value: { type: String },
+  };
+
+  // Slotted elements remain in lightDOM which allows for control of their style outside of shadowDOM.
+  // ::slotted([Simple Selector]) confirms to Specificity rules, but (being simple) does not add weight to lightDOM skin selectors,
+  // so never gets higher Specificity. Thus in order to overwrite style linked within shadowDOM, we need to use !important.
+  // https://stackoverflow.com/a/61631668
+  static styles = css`
+    :host {
+      display: block;
+    }
+    ::slotted(:last-child) {
+      margin-bottom: 0px !important;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.type = 'text';
+  }
+
+  get _outerWrapperStyles() {
+    return fclasses({
+      // 'has-suffix': hasSuffix,
+      // 'has-prefix': hasPrefix,
+    });
+  }
+
+  get _innerWrapperStyles() {
+    return fclasses({
+      'input mb-0': true,
+      'input--is-invalid': this.invalid,
+      'input--is-disabled': this.disabled,
+      'input--is-read-only': this.readOnly,
+    });
+  }
+
+  get _label() {
+    if (this.label) {
+      return html`<label for="${this._id}">${this.label}</label>`;
+    }
+  }
+
+  get _helpId() {
+    if (this.helpText) return `${this._id}__hint`;
+  }
+
+  get _id() {
+    return 'textfield';
+  }
+
+  get _error() {
+    if (this.invalid && this._helpId) return this._helpId;
+  }
+
+  blurHandler(e) {
+    this.dispatchEvent(new CustomEvent('blur'));
+  }
+
+  changeHandler(e) {
+    this.dispatchEvent(new CustomEvent('change'));
+  }
+
+  focusHandler(e) {
+    this.dispatchEvent(new CustomEvent('focus'));
+  }
+
+  render() {
+    return html`
+      ${this._fabricStylesheet}
+      <div class="${this._outerWrapperStyles}">
+        <div class="${this._innerWrapperStyles}">
+          ${this._label}
+          <div class="relative">
+            <input
+              type="${this.type}"
+              min="${ifDefined(this.min)}"
+              max="${ifDefined(this.max)}"
+              minlength="${ifDefined(this.minLength)}"
+              maxlength="${ifDefined(this.maxLength)}"
+              name="${ifDefined(this.name)}"
+              pattern="${ifDefined(this.pattern)}"
+              placeholder="${ifDefined(this.placeholder)}"
+              value="${ifDefined(this.value)}"
+              aria-describedby="${ifDefined(this._helpId)}"
+              aria-errormessage="${ifDefined(this._error)}"
+              aria-invalid="${ifDefined(this.invalid)}"
+              id="${this._id}"
+              ?disabled="${this.disabled}"
+              ?readonly="${this.readOnly}"
+              ?required="${this.required}"
+              @onBlur=${this.blurHandler}
+              @onChange=${this.changeHandler}
+              @onFocus=${this.focusHandler}
+            />
+            <slot></slot>
+          </div>
+          ${this.helpText &&
+          html`<div class="input__sub-text" id="${this._helpId}">${this.helpText}</div>`}
+        </div>
+      </div>
+    `;
+  }
+}
+
+if (!customElements.get('f-textfield')) {
+  customElements.define('f-textfield', FabricTextField);
+}
+
+export { FabricTextField };

--- a/packages/textfield/test.js
+++ b/packages/textfield/test.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef */
+// /* eslint-disable no-undef */
 import tap, { test, beforeEach, teardown } from 'tap';
 import { chromium } from 'playwright';
 import { addContentToPage } from '../../tests/utils/index.js';
@@ -155,4 +155,78 @@ test('Disabled component with label and value is rendered on the page', async (t
   // THEN: the component is visible in the DOM
   t.equal(await page.locator('text=E-post').isVisible(), true, 'Help text should be visible')
   t.equal(await page.locator('input').getAttribute('disabled'), '', 'Disabled should be set on input')
+});
+
+test('Component with prefix is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield label="Price" placeholder="1 000 000">
+      <f-affix slot="prefix" label="kr"></f-affix>
+    </f-textfield>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  t.equal(await page.locator('text=kr').isVisible(), true, 'Prefix text should be visible')
+});
+
+test('Component with search suffix is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield label="Price" placeholder="1 000 000">
+      <f-affix slot="suffix" search></f-affix>
+    </f-textfield>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  t.equal(await page.locator('button[type=submit]').isVisible(), true, 'Suffix search button should be visible')
+});
+
+test('Component with clear suffix is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield label="Price" placeholder="1 000 000">
+      <f-affix slot="suffix" clear></f-affix>
+    </f-textfield>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  t.equal(await page.locator('button[type=reset]').isVisible(), true, 'Suffix clear button should be visible')
+});
+
+test('Component with prefix label and clear suffix is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield label="Price" placeholder="1 000 000">
+      <f-affix slot="prefix" label="kr"></f-affix>
+      <f-affix slot="suffix" clear></f-affix>
+    </f-textfield>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  t.equal(await page.locator('text=kr').isVisible(), true, 'Prefix text should be visible')
+  t.equal(await page.locator('button[type=reset]').isVisible(), true, 'Suffix clear button should be visible')
 });

--- a/packages/textfield/test.js
+++ b/packages/textfield/test.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-undef */
+import tap, { test, beforeEach, teardown } from 'tap';
+import { chromium } from 'playwright';
+import { addContentToPage } from '../../tests/utils/index.js';
+
+tap.before(async () => {
+  const browser = await chromium.launch({ headless: true });
+  tap.context.browser = browser;
+});
+
+beforeEach(async (t) => {
+  const { browser } = t.context;
+  const context = await browser.newContext();
+  t.context.page = await context.newPage();
+});
+
+teardown(async () => {
+  const { browser } = tap.context;
+  browser.close();
+});
+
+test('Text field component with a value attribute is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield value="this is a textfield"></f-textfield>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  const locator = await page.locator('f-textfield');
+  t.equal(await locator.getAttribute('value'), 'this is a textfield', 'value should be defined');
+});

--- a/packages/textfield/test.js
+++ b/packages/textfield/test.js
@@ -98,8 +98,12 @@ test('Text field component with a label and help text is rendered on the page', 
   });
 
   // THEN: the component is visible in the DOM
-  t.equal(await page.locator('text=Telefonnummer').isVisible(), true, 'Label should be visible')
-  t.equal(await page.locator('text=Vil kun brukes til brukerverifisering').isVisible(), true, 'Help text should be visible')
+  t.equal(await page.locator('text=Telefonnummer').isVisible(), true, 'Label should be visible');
+  t.equal(
+    await page.locator('text=Vil kun brukes til brukerverifisering').isVisible(),
+    true,
+    'Help text should be visible',
+  );
 });
 
 test('Invalid component with label and help text is rendered on the page', async (t) => {
@@ -119,8 +123,16 @@ test('Invalid component with label and help text is rendered on the page', async
   });
 
   // THEN: the component is visible in the DOM
-  t.equal(await page.locator('text=Ugyldig e-post').isVisible(), true, 'Help text should be visible')
-  t.equal(await page.locator('input').getAttribute('aria-invalid'), 'true', 'Aria invalid should be set')
+  t.equal(
+    await page.locator('text=Ugyldig e-post').isVisible(),
+    true,
+    'Help text should be visible',
+  );
+  t.equal(
+    await page.locator('input').getAttribute('aria-invalid'),
+    'true',
+    'Aria invalid should be set',
+  );
 });
 
 test('Invalid component with label and help text is rendered on the page', async (t) => {
@@ -136,8 +148,12 @@ test('Invalid component with label and help text is rendered on the page', async
   });
 
   // THEN: the component is visible in the DOM
-  t.equal(await page.locator('text=E-post').isVisible(), true, 'Help text should be visible')
-  t.equal(await page.locator('input').getAttribute('placeholder'), 'puse@finn.no', 'Placeholder text should be visible')
+  t.equal(await page.locator('text=E-post').isVisible(), true, 'Help text should be visible');
+  t.equal(
+    await page.locator('input').getAttribute('placeholder'),
+    'puse@finn.no',
+    'Placeholder text should be visible',
+  );
 });
 
 test('Disabled component with label and value is rendered on the page', async (t) => {
@@ -153,8 +169,12 @@ test('Disabled component with label and value is rendered on the page', async (t
   });
 
   // THEN: the component is visible in the DOM
-  t.equal(await page.locator('text=E-post').isVisible(), true, 'Help text should be visible')
-  t.equal(await page.locator('input').getAttribute('disabled'), '', 'Disabled should be set on input')
+  t.equal(await page.locator('text=E-post').isVisible(), true, 'Help text should be visible');
+  t.equal(
+    await page.locator('input').getAttribute('disabled'),
+    '',
+    'Disabled should be set on input',
+  );
 });
 
 test('Component with prefix is rendered on the page', async (t) => {
@@ -172,7 +192,7 @@ test('Component with prefix is rendered on the page', async (t) => {
   });
 
   // THEN: the component is visible in the DOM
-  t.equal(await page.locator('text=kr').isVisible(), true, 'Prefix text should be visible')
+  t.equal(await page.locator('text=kr').isVisible(), true, 'Prefix text should be visible');
 });
 
 test('Component with search suffix is rendered on the page', async (t) => {
@@ -190,7 +210,11 @@ test('Component with search suffix is rendered on the page', async (t) => {
   });
 
   // THEN: the component is visible in the DOM
-  t.equal(await page.locator('button[type=submit]').isVisible(), true, 'Suffix search button should be visible')
+  t.equal(
+    await page.locator('button[type=submit]').isVisible(),
+    true,
+    'Suffix search button should be visible',
+  );
 });
 
 test('Component with clear suffix is rendered on the page', async (t) => {
@@ -208,7 +232,11 @@ test('Component with clear suffix is rendered on the page', async (t) => {
   });
 
   // THEN: the component is visible in the DOM
-  t.equal(await page.locator('button[type=reset]').isVisible(), true, 'Suffix clear button should be visible')
+  t.equal(
+    await page.locator('button[type=reset]').isVisible(),
+    true,
+    'Suffix clear button should be visible',
+  );
 });
 
 test('Component with prefix label and clear suffix is rendered on the page', async (t) => {
@@ -227,6 +255,40 @@ test('Component with prefix label and clear suffix is rendered on the page', asy
   });
 
   // THEN: the component is visible in the DOM
-  t.equal(await page.locator('text=kr').isVisible(), true, 'Prefix text should be visible')
-  t.equal(await page.locator('button[type=reset]').isVisible(), true, 'Suffix clear button should be visible')
+  t.equal(await page.locator('text=kr').isVisible(), true, 'Prefix text should be visible');
+  t.equal(
+    await page.locator('button[type=reset]').isVisible(),
+    true,
+    'Suffix clear button should be visible',
+  );
+});
+
+test('Affix component button events bubble', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield label="Price" placeholder="1 000 000">
+      <f-affix slot="suffix" clear></f-affix>
+    </f-textfield>
+    <script>
+      const el = document.querySelector('f-affix');
+      el.addEventListener('click', (e) => {
+        el.setAttribute('hasBeenClicked', true);
+      });
+    </script>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  const loc = await page.locator('button[type=reset]');
+  await loc.click();
+  t.equal(
+    await page.locator('f-affix').getAttribute('hasBeenClicked'),
+    'true',
+    'Clicked element should have bubbled to the parent',
+  );
 });

--- a/packages/textfield/test.js
+++ b/packages/textfield/test.js
@@ -35,3 +35,124 @@ test('Text field component with a value attribute is rendered on the page', asyn
   const locator = await page.locator('f-textfield');
   t.equal(await locator.getAttribute('value'), 'this is a textfield', 'value should be defined');
 });
+
+test('Text field number component with a min and max is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield min="10" max="20" value="15" type="number"></f-textfield>
+    <script>
+      const el = document.querySelector('f-textfield')
+      el.addEventListener('change', (e) => {
+        el.value = e.detail.value;
+      });
+    </script>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  let locator = await page.locator('input');
+  await locator.click();
+  await locator.fill('10');
+  await page.keyboard.press('Tab');
+  t.equal(await locator.inputValue(), '10', 'value should be 10');
+
+  await page.locator('f-textfield');
+  t.equal(await locator.getAttribute('value'), '10', 'value should be 10');
+});
+
+test('Text field component with a label is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield label="Name of a person"></f-textfield>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  let locator = await page.locator('text=Name of a person');
+  t.equal(await locator.isVisible(), true, 'Label should be visible');
+});
+
+test('Text field component with a label and help text is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield 
+      label="Telefonnummer"
+      help-text="Vil kun brukes til brukerverifisering">
+    </f-textfield>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  t.equal(await page.locator('text=Telefonnummer').isVisible(), true, 'Label should be visible')
+  t.equal(await page.locator('text=Vil kun brukes til brukerverifisering').isVisible(), true, 'Help text should be visible')
+});
+
+test('Invalid component with label and help text is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield 
+      label="E-post"
+      invalid
+      help-text="Ugyldig e-post">
+    </f-textfield>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  t.equal(await page.locator('text=Ugyldig e-post').isVisible(), true, 'Help text should be visible')
+  t.equal(await page.locator('input').getAttribute('aria-invalid'), 'true', 'Aria invalid should be set')
+});
+
+test('Invalid component with label and help text is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield label="E-post" placeholder="puse@finn.no"></f-textfield>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  t.equal(await page.locator('text=E-post').isVisible(), true, 'Help text should be visible')
+  t.equal(await page.locator('input').getAttribute('placeholder'), 'puse@finn.no', 'Placeholder text should be visible')
+});
+
+test('Disabled component with label and value is rendered on the page', async (t) => {
+  // GIVEN: A box component
+  const component = `
+    <f-textfield label="E-post" disabled value="puse@finn.no"></f-textfield>
+  `;
+
+  // WHEN: the component is added to the page
+  const page = await addContentToPage({
+    page: t.context.page,
+    content: component,
+  });
+
+  // THEN: the component is visible in the DOM
+  t.equal(await page.locator('text=E-post').isVisible(), true, 'Help text should be visible')
+  t.equal(await page.locator('input').getAttribute('disabled'), '', 'Disabled should be set on input')
+});

--- a/pages/components/textfield.html
+++ b/pages/components/textfield.html
@@ -180,22 +180,6 @@
               <td></td>
             </tr>
             <tr>
-              <td>prefix</td>
-              <td>
-                <div>boolean</div>
-                <div class="annotation">Set automatically by f-textfield element.</div>
-              </td>
-              <td>false</td>
-            </tr>
-            <tr>
-              <td>suffix</td>
-              <td>
-                <div>boolean</div>
-                <div class="annotation">Set automatically by f-textfield element.</div>
-              </td>
-              <td>false</td>
-            </tr>
-            <tr>
               <td>clear</td>
               <td>
                 <div>boolean</div>

--- a/pages/components/textfield.html
+++ b/pages/components/textfield.html
@@ -1,0 +1,332 @@
+<html lang="en">
+  <%- include('head.html'); -%>
+  <body>
+    <f-docs-template>
+      <%- include('nav.html'); -%>
+      <main slot="content">
+        <h1 class="mb-16">Textfield</h1>
+        <p>A single line text input element.</p>
+
+        <h2 class="mt-24 mb-16">Textfield Attributes</h2>
+        <table class="w-full docs-table">
+          <thead>
+            <tr class="text-left text-gray-400 uppercase">
+              <th>prop</th>
+              <th>type</th>
+              <th>default</th>
+            </tr>
+          </thead>
+          <tbody class="align-top">
+            <tr>
+              <td>disabled</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">Whether the input is disabled.</div>
+              </td>
+              <td>false</td>
+            </tr>
+            <tr>
+              <td>invalid</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">
+                  Renders the field in an invalid state. Often paired together with help-text to
+                  provide feedback about the error.
+                </div>
+              </td>
+              <td>false</td>
+            </tr>
+            <tr>
+              <td>help-text</td>
+              <td>
+                <div>string</div>
+                <div class="annotation">The content to display as the help text.</div>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>label</td>
+              <td>
+                <div>string</div>
+                <div class="annotation">The content to display as the label.</div>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>min</td>
+              <td>
+                <div>number</div>
+                <div class="annotation">
+                  Standard input min attribute, to be used with type="number". See MDN.
+                </div>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>
+                <div>number</div>
+                <div class="annotation">
+                  Standard input max attribute, to be used with type="number". See MDN.
+                </div>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>min-length</td>
+              <td>
+                <div>number</div>
+                <div class="annotation">
+                  The minimum number of characters supported by the input. See MDN.
+                </div>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>max-length</td>
+              <td>
+                <div>number</div>
+                <div class="annotation">
+                  The maximum number of characters supported by the input. See MDN.
+                </div>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>name</td>
+              <td>
+                <div>string</div>
+                <div class="annotation">
+                  The name of the input element, used when submitting an HTML form. See MDN.
+                </div>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>pattern</td>
+              <td>
+                <div>string</div>
+                <div class="annotation">
+                  Regex pattern that the value of the input must match to be valid. See MDN.
+                </div>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>placeholder</td>
+              <td>
+                <div>string</div>
+                <div class="annotation">
+                  Text hint that occupies the text input when it is empty.
+                </div>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>read-only</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">
+                  Whether the input can be selected but not changed by the user.
+                </div>
+              </td>
+              <td>false</td>
+            </tr>
+            <tr>
+              <td>required</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">
+                  Whether user input is required on the input before form submission.
+                </div>
+              </td>
+              <td>false</td>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>
+                <div>string</div>
+                <div class="annotation">The type of input to render. See MDN.</div>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">The current value.</div>
+              </td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2 class="mt-24 mb-16">Affix Attributes</h2>
+        <table class="w-full docs-table">
+          <thead>
+            <tr class="text-left text-gray-400 uppercase">
+              <th>prop</th>
+              <th>type</th>
+              <th>default</th>
+            </tr>
+          </thead>
+          <tbody class="align-top">
+            <tr>
+              <td>aria-label</td>
+              <td>
+                <div>string</div>
+                <div class="annotation">Defines a string value that labels the affix element.</div>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>prefix</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">Set automatically by f-textfield element.</div>
+              </td>
+              <td>false</td>
+            </tr>
+            <tr>
+              <td>suffix</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">Set automatically by f-textfield element.</div>
+              </td>
+              <td>false</td>
+            </tr>
+            <tr>
+              <td>clear</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">Displays a clear icon.</div>
+              </td>
+              <td>false</td>
+            </tr>
+            <tr>
+              <td>search</td>
+              <td>
+                <div>boolean</div>
+                <div class="annotation">Displays a search icon.</div>
+              </td>
+              <td>false</td>
+            </tr>
+            <tr>
+              <td>label</td>
+              <td>
+                <div>string</div>
+                <div class="annotation">Displays a string</div>
+              </td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2 class="mt-24 mb-16">Validation</h2>
+
+        Text fields can communicate to the user whether the current value is invalid. Implement your
+        own validation logic in your app and set the error prop to display it as invalid. <i>error</i> is
+        often paired with <i>help-text</i> to provide feedback to the user about the error.
+
+        <syntax-highlight>
+          <f-textfield label="Email" invalid help-text="Ugyldig e-post"></f-textfield>
+        </syntax-highlight>
+        <div class="example">
+          <f-textfield label="Email" invalid help-text="Ugyldig e-post"></f-textfield>
+        </div>
+
+        <h2 class="mt-24 mb-16">Visual Options</h2>
+
+        <h3 class="mt-24 mb-16">Placeholder</h3>
+        <syntax-highlight>
+          <f-textfield label="E-post" placeholder="puse@finn.no"></f-textfield>
+        </syntax-highlight>
+        <div class="example">
+          <f-textfield label="E-post" placeholder="puse@finn.no"></f-textfield>
+        </div>
+        Placeholder text can be used to describe the expected value or formatting for the f-textfield.
+        Placeholder text will only appear when the f-textfield is empty, and should not be used as a
+        substitute for labeling the element with a visible label.
+
+        <h3 class="mt-24 mb-16">Disabled</h3>
+        Keep in mind that using disabled in its current form is an anti-pattern. There will ALWAYS
+        be users who don't understand why an element is disabled, or users who can't even see that
+        it is disabled because of poor lighting conditions or other reasons. Please consider more
+        informative alternatives before choosing to use disabled on an element.
+        <syntax-highlight>
+          <div class="flex flex-col space-y-32">
+            <f-textfield label="E-post" disabled value="puse@finn.no"></f-textfield>
+            <f-textfield label="E-post" disabled></f-textfield>
+          </div>
+        </syntax-highlight>
+        <div class="example">
+          <div class="flex flex-col space-y-32">
+            <f-textfield label="E-post" disabled value="puse@finn.no"></f-textfield>
+            <f-textfield label="E-post" disabled></f-textfield>
+          </div>
+        </div>
+
+        <h3 class="mt-24 mb-16">Affix</h3>
+        If you wish to use an affix you must first use the f-affix element in conjunction with
+        f-textfield. Include the affix as a child of f-textfield and set the appropiate attributes.
+        You must specify which slot to set the affix into (either prefix or suffix).
+        <syntax-highlight>
+          <f-textfield label="Price" placeholder="1 000 000">
+            <f-affix slot="suffix" label="kr"></f-affix>
+          </f-textfield>
+        </syntax-highlight>
+        <div class="example">
+          <f-textfield label="Price" placeholder="1 000 000">
+            <f-affix slot="suffix" label="kr"></f-affix>
+          </f-textfield>
+        </div>
+        <syntax-highlight>
+          <f-textfield label="Price" placeholder="1 000 000">
+            <f-affix slot="prefix" label="kr"></f-affix>
+          </f-textfield>
+        </syntax-highlight>
+        <div class="example">
+          <f-textfield label="Price" placeholder="1 000 000">
+            <f-affix slot="prefix" label="kr"></f-affix>
+          </f-textfield>
+        </div>
+
+        You can also use both a prefix and suffix
+        <syntax-highlight>
+          <f-textfield label="Price" placeholder="1 000 000">
+            <f-affix slot="prefix" label="kr"></f-affix>
+            <f-affix slot="suffix" search></f-affix>
+          </f-textfield>
+        </syntax-highlight>
+        <div class="example">
+          <f-textfield label="Price" placeholder="1 000 000">
+            <f-affix slot="prefix" label="kr"></f-affix>
+            <f-affix slot="suffix" search></f-affix>
+          </f-textfield>
+        </div>
+
+        <h3 class="mt-24 mb-16">Read only</h3>
+
+        The read-only boolean attribute makes the f-textfield's text content immutable. Unlike
+        disabled the f-textfield remains focusable and the contents can still be copied. See the MDN
+        docs for more information.
+
+        <syntax-highlight>
+          <div class="flex flex-col space-y-32">
+            <f-textfield label="E-post" read-only value="puse@finn.no"></f-textfield>
+            <f-textfield label="E-post" read-only></f-textfield>
+          </div>
+        </syntax-highlight>
+        <div class="example">
+          <div class="flex flex-col space-y-32">
+            <f-textfield label="E-post" read-only value="puse@finn.no"></f-textfield>
+            <f-textfield label="E-post" read-only></f-textfield>
+          </div>
+        </div>
+      </main>
+      <%- include('footer.html'); -%>
+    </f-docs-template>
+
+    <%- include('scripts.html'); -%>
+  </body>
+</html>

--- a/pages/includes/nav.html
+++ b/pages/includes/nav.html
@@ -3,6 +3,26 @@
     "category": "Elements",
     "items": [
       {
+        "title": "Feedback Indicators",
+        "open": true,
+        "items": [
+          {
+            "title": "Alert",
+            "href": "/pages/components/alert.html"
+          }
+        ]
+      },
+      {
+        "title": "Forms",
+        "open": true,
+        "items": [
+          {
+            "title": "Textfield",
+            "href": "/pages/components/textfield.html"
+          }
+        ]
+      },
+      {
         "title": "Layout",
         "open": true,
         "items": [
@@ -31,16 +51,6 @@
           {
             "title": "Breadcrumbs",
             "href": "/pages/components/breadcrumbs.html"
-          }
-        ]
-      },
-      {
-        "title": "Feedback Indicators",
-        "open": true,
-        "items": [
-          {
-            "title": "Alert",
-            "href": "/pages/components/alert.html"
           }
         ]
       }

--- a/vite.config.js
+++ b/vite.config.js
@@ -75,6 +75,11 @@ export default ({ mode }) => {
             injectOptions,
           },
           {
+            filename: 'textfield.html',
+            template: 'pages/components/textfield.html',
+            injectOptions,
+          },
+          {
             filename: 'index.html',
             template: 'index.html',
             injectOptions,


### PR DESCRIPTION
Adds a textfield element based on the React version.

TODO
* [x] prefix/suffix
* [x] more tests
* [x] docs

This is ready for feedback now. It's a pretty direct port of the React version.
I haven't attempted to spread out additional attributes onto the input.
Will wait for the result of the RFC discussion here https://github.com/fabric-ds/issues/pull/101 though this component contains a fairly large set of possible attributes already.